### PR TITLE
fixed etcd failure and hystrix timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ understand demo is provided.
 Please read the [blog post](http://servicecomb.io/docs/linuxcon-workshop-demo/) on the detailed explanation of this project.
 
 ## Run Services
-A `docker-compose.yaml` file is provided to start all services an their dependencies as docker containers.
+A `docker-compose.yaml` file is provided to start all services and their dependencies as docker containers.
 1. Build all service images using command `mvn package -Pdocker`
 1. Run all service images using command `docker-compose up`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "9411:9411"
   company-bulletin-board:
     image: "servicecomb/service-center"
-    hostname: service.center
+    hostname: service-center
     ports:
       - "30100:30100"
 

--- a/manager/src/main/resources/application.yaml
+++ b/manager/src/main/resources/application.yaml
@@ -22,40 +22,15 @@ spring:
 server:
   port: 0
 
-hystrix:
-  execution:
-    isolation:
-      strategy: THREAD
-  command:
-    default:
-      execution:
-        isolation:
-          thread:
-            timeoutInMilliseconds: 5000
-
 ---
 
 spring:
   profiles: sit
-hystrix:
-  command:
-    default:
-      execution:
-        isolation:
-          thread:
-            timeoutInMilliseconds: 10000
 
 ---
 
 spring:
   profiles: dev
-hystrix:
-  command:
-    default:
-      execution:
-        isolation:
-          thread:
-            timeoutInMilliseconds: 1000
 
 logging:
   level:

--- a/manager/src/main/resources/microservice.yaml
+++ b/manager/src/main/resources/microservice.yaml
@@ -8,6 +8,13 @@ cse:
   service:
     registry:
       address: http://sc.servicecomb.io:30100
+  isolation:
+    doorman:
+      timeoutInMilliseconds: 30000
+    beekeeper:
+      timeoutInMilliseconds: 30000
+    worker:
+      timeoutInMilliseconds: 30000
   handler:
     chain:
       Provider:


### PR DESCRIPTION
Hostname of etcd can not be a valid dns hostname or the hostname's ip address must be the same as the dns record's ip address, otherwise etcd will print error like "bind: cannot assign requested address" and refuse to start. In our docker-compose file, as `service.center` is a valid dns record, and our ip address didn't match that record.