### PR TITLE
JAV-288: 优化本地IDE运行配置

### DIFF
--- a/beekeeper/src/main/resources/microservice.yaml
+++ b/beekeeper/src/main/resources/microservice.yaml
@@ -7,9 +7,9 @@ service_description:
 cse:
   service:
     registry:
-      address: http://sc.servicecomb.io:30100
+      address: http://127.0.0.1:30100
   rest:
-    address: 0.0.0.0:8090
+    address: 0.0.0.0:9093
   handler:
     chain:
       Consumer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,11 @@ services:
       - "company-bulletin-board:sc.servicecomb.io"
       - "zipkin:zipkin.io"
     environment:
+      - JAVA_OPTS="-Dcse.service.registry.address=http://sc.servicecomb.io:30100"
       - ARTIFACT_ID=worker
     ports:
       - "7070:7070"
-      - "8080:8080"
+      - "8080:9091"
 
   company-doorman:
     image: "doorman:0.0.1-SNAPSHOT"
@@ -31,10 +32,10 @@ services:
       - "company-bulletin-board:sc.servicecomb.io"
       - "zipkin:zipkin.io"
     environment:
-      - JAVA_OPTS=-Dcompany.auth.secret=someSecretKey
+      - JAVA_OPTS="-Dcompany.auth.secret=someSecretKey -Dcse.service.registry.address=http://sc.servicecomb.io:30100"
       - ARTIFACT_ID=doorman
     ports:
-      - "8081:8080"
+      - "8081:9092"
 
   company-beekeeper:
     image: "beekeeper:0.0.1-SNAPSHOT"
@@ -44,9 +45,10 @@ services:
       - "zipkin:zipkin.io"
       - "company-worker"
     environment:
+      - JAVA_OPTS="-Dcse.service.registry.address=http://sc.servicecomb.io:30100"
       - ARTIFACT_ID=beekeeper
     ports:
-      - "8082:8090"
+      - "8082:9093"
 
   company-manager:
     image: "manager:0.0.1-SNAPSHOT"
@@ -55,7 +57,7 @@ services:
       - "company-bulletin-board:sc.servicecomb.io"
       - "zipkin:zipkin.io"
     environment:
-      - JAVA_OPTS=-Dserver.port=8080 #-Dlogging.level.root=DEBUG
+      - JAVA_OPTS="-Dcse.service.registry.address=http://sc.servicecomb.io:30100"  #-Dlogging.level.root=DEBUG
       - ARTIFACT_ID=manager
     ports:
       - "8083:8080"

--- a/doorman/src/main/resources/microservice.yaml
+++ b/doorman/src/main/resources/microservice.yaml
@@ -7,9 +7,9 @@ service_description:
 cse:
   service:
     registry:
-      address: http://sc.servicecomb.io:30100
+      address: http://127.0.0.1:30100
   rest:
-    address: 0.0.0.0:8080
+    address: 0.0.0.0:8082
   handler:
     chain:
       Provider:

--- a/manager/src/main/resources/application.yaml
+++ b/manager/src/main/resources/application.yaml
@@ -20,7 +20,7 @@ spring:
       port: 30100
 
 server:
-  port: 0
+  port: 8080
 
 ---
 

--- a/manager/src/main/resources/microservice.yaml
+++ b/manager/src/main/resources/microservice.yaml
@@ -7,7 +7,7 @@ service_description:
 cse:
   service:
     registry:
-      address: http://sc.servicecomb.io:30100
+      address: http://127.0.0.1:30100
   isolation:
     doorman:
       timeoutInMilliseconds: 30000

--- a/worker/src/main/resources/microservice.yaml
+++ b/worker/src/main/resources/microservice.yaml
@@ -7,11 +7,11 @@ service_description:
 cse:
   service:
     registry:
-      address: http://sc.servicecomb.io:30100
+      address: http://127.0.0.1:30100
   highway:
     address: 0.0.0.0:7070
   rest:
-    address: 0.0.0.0:8080
+    address: 0.0.0.0:9091
   handler:
     chain:
       Provider:


### PR DESCRIPTION
https://servicecomb.atlassian.net/browse/JAV-288

修改点：
1、本地微服务描述文件，服务中心地址默认改为127.0.0.1方便连接本地调试直接启动服务中心。（不影响docker-compose域名连接服务中心，docker-compose.yml通过环境变量传入即可）
2、各微服务默认端口需要不同，以免非容器环境单机会冲突。
3、manager服务对外端口默认开启，不需要额外参数传入，简化运行