### PR TITLE
added default secret key for doorman

### DIFF
--- a/doorman/src/main/java/io/servicecomb/company/auth/AuthenticationConfig.java
+++ b/doorman/src/main/java/io/servicecomb/company/auth/AuthenticationConfig.java
@@ -33,7 +33,7 @@ class AuthenticationConfig {
   }
 
   @Bean
-  TokenStore tokenStore(@Value("${company.auth.secret}") String secretKey) {
+  TokenStore tokenStore(@Value("${company.auth.secret:someSecretKey}") String secretKey) {
     return new JwtTokenStore(secretKey, SECONDS_OF_A_DAY);
   }
 }


### PR DESCRIPTION
Default secret key should be set in this way instead of Tank Tian's way. In his way, the doorman still refuse to start because the lack of `company.auth.secret`.