### PR TITLE
Remove APM config in manager.yml

### DIFF
--- a/etc/microservice/manager.yaml
+++ b/etc/microservice/manager.yaml
@@ -21,9 +21,9 @@ cse:
   handler:
     chain:
       Provider:
-        default: tracing-provider-apm,kpi-provider-apm,bizkeeper-provider,perf-stats,qps-flowcontrol-provider
+        default: bizkeeper-provider,perf-stats,qps-flowcontrol-provider
       Consumer:
-        default: loadbalance,tracing-consumer-apm,kpi-consumer-apm,bizkeeper-consumer,perf-stats,qps-flowcontrol-consumer
+        default: loadbalance,bizkeeper-consumer,perf-stats,qps-flowcontrol-consumer
   config:
     client:
       serverUri: https://100.125.1.34:30103


### PR DESCRIPTION
Remove APM config in manager.yml,cause it would be set when deployed on ServiceStage.

Signed-off-by: MabinGo <bin.ma@huawei.com>