### PR TITLE
fix "javax.sql.DataSource that could not be found" problem when debug with IDE

### DIFF
--- a/doorman/pom.xml
+++ b/doorman/pom.xml
@@ -105,6 +105,12 @@
       <artifactId>pact-jvm-model_2.11</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>
Fix "javax.sql.DataSource that could not be found" problem when debug with IDE

Doorman use spring JPA as default database orm implement.
It need spring-jdbc, but default imported scope from JPA is `provide`, so we need change it to `compile`




