### PR TITLE
Update images' version in kubernetes yamls

### DIFF
--- a/kubernetes/company-beekeeper-deployment.yaml
+++ b/kubernetes/company-beekeeper-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: beekeeper
         - name: JAVA_OPTS
           value: -Dcse.service.registry.address=http://company-bulletin-board:30100 -Dservicecomb.tracing.collector.adress=http://zipkin:9411
-        image: servicecomb/beekeeper:0.0.1-SNAPSHOT
+        image: servicecomb/beekeeper:1.0.0-SNAPSHOT
         name: company-beekeeper
         ports:
         - containerPort: 8090

--- a/kubernetes/company-doorman-deployment.yaml
+++ b/kubernetes/company-doorman-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: doorman
         - name: JAVA_OPTS
           value: -Dcse.service.registry.address=http://company-bulletin-board:30100 -Dservicecomb.tracing.collector.adress=http://zipkin:9411 -Dspring.profiles.active=prd -Dspring.datasource.url=jdbc:mysql://company-mysql:3306/company
-        image: servicecomb/doorman:0.0.1-SNAPSHOT
+        image: servicecomb/doorman:1.0.0-SNAPSHOT
         name: company-doorman
         ports:
         - containerPort: 8080

--- a/kubernetes/company-manager-deployment.yaml
+++ b/kubernetes/company-manager-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: manager
         - name: JAVA_OPTS
           value: -Dserver.port=8080 -Dcse.service.registry.address=http://company-bulletin-board:30100 -Dservicecomb.tracing.collector.adress=http://zipkin:9411
-        image: servicecomb/manager:0.0.1-SNAPSHOT
+        image: servicecomb/manager:1.0.0-SNAPSHOT
         name: company-manager
         ports:
         - containerPort: 8080

--- a/kubernetes/company-worker-deployment.yaml
+++ b/kubernetes/company-worker-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           value: worker
         - name: JAVA_OPTS
           value: -Dcse.service.registry.address=http://company-bulletin-board:30100 -Dservicecomb.tracing.collector.adress=http://zipkin:9411
-        image: servicecomb/worker:0.0.1-SNAPSHOT
+        image: servicecomb/worker:1.0.0-SNAPSHOT
         name: company-worker
         ports:
         - containerPort: 7070


### PR DESCRIPTION
I've tested the 1.0.0-SNAPSHOT builds under kubernetes, everything works just fine.

There is an `Internal Server Error` when calling the Fibonacci number service, complaining timeout of socket read, it should be something related to zuul/robbin/hystrix configs, I'll dig more into it.

Last, make sure to push images of 1.0.0-SNAPSHOT to docker hub before merging this PR.