### PR TITLE
Add commands to push the newly built images in travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,13 @@ services:
 
 script:
   - mvn clean install -Ddocker.useColor=false -Ddocker.showLogs -Pdocker -Pjacoco coveralls:report
+  - version=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - docker tag worker:${version} servicecomb/worker:${version}
+  - docker push servicecomb/worker:${version}
+  - docker tag beekeeper:${version} servicecomb/beekeeper:${version}
+  - docker push servicecomb/beekeeper:${version}
+  - docker tag doorman:${version} servicecomb/doorman:${version}
+  - docker push servicecomb/doorman:${version}
+  - docker tag manager:${version} servicecomb/manager:${version}
+  - docker push servicecomb/manager:${version}

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,7 @@ services:
 
 script:
   - mvn clean install -Ddocker.useColor=false -Ddocker.showLogs -Pdocker -Pjacoco coveralls:report
-  - version=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  - docker tag worker:${version} servicecomb/worker:${version}
-  - docker push servicecomb/worker:${version}
-  - docker tag beekeeper:${version} servicecomb/beekeeper:${version}
-  - docker push servicecomb/beekeeper:${version}
-  - docker tag doorman:${version} servicecomb/doorman:${version}
-  - docker push servicecomb/doorman:${version}
-  - docker tag manager:${version} servicecomb/manager:${version}
-  - docker push servicecomb/manager:${version}
+
+after_success:
+  - if [ "$TRAVIS_TAG" != "" ]; then bash -x ./scripts/release.sh ; fi
+

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+## Make sure to run the script under project root folder.
+version=$(printf 'VER\t${project.version}' | mvn help:evaluate | grep '^VER' | cut -f2)
+
+if [ "${version}" == "" ]; then
+	echo "Failed to get project version"
+	exit 1
+fi
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker tag worker:${version} servicecomb/worker:${version}
+docker push servicecomb/worker:${version}
+docker tag beekeeper:${version} servicecomb/beekeeper:${version}
+docker push servicecomb/beekeeper:${version}
+docker tag doorman:${version} servicecomb/doorman:${version}
+docker push servicecomb/doorman:${version}
+docker tag manager:${version} servicecomb/manager:${version}
+docker push servicecomb/manager:${version}


### PR DESCRIPTION
After building the images with `mvn clean install`:
- get the project version by `mvn help`
- login to docker hub(using env var $DOCKER_PASSWORD and $DOCKER_USERNAME)
- tag the images and push them to dockerhub