### PR TITLE
remove highway endpoint in worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
     environment:
       - ARTIFACT_ID=worker
     ports:
-      - "7070:7070"
       - "8080:8080"
 
   company-doorman:

--- a/worker/src/main/resources/microservice.yaml
+++ b/worker/src/main/resources/microservice.yaml
@@ -8,8 +8,6 @@ cse:
   service:
     registry:
       address: http://sc.servicecomb.io:30100
-  highway:
-    address: 0.0.0.0:7070
   rest:
     address: 0.0.0.0:8080
   handler:


### PR DESCRIPTION
remove highway endpoint in worker because servicecomb integration with zuul do not support (ONLY REST SUPPORTED)

Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>